### PR TITLE
Add INT trap to exit when C-c

### DIFF
--- a/bgm.rb
+++ b/bgm.rb
@@ -64,6 +64,8 @@ class BGM
   end
 end
 
+trap(:INT) { exit }
+
 term = ARGV.shift
 
 unless term


### PR DESCRIPTION
Current: C-c to kill player and play next music.
This patch: C-c to exit bgm.rb
