### PR TITLE
Add --shuffle to shuffle tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ bundle exec -- ruby bgm.rb dubstep --rate 0.5
 bundle exec -- ruby bgm.rb dubstep --async
 ```
 
+## PLAY TRACKS AT RANDOM
+
+```
+bundle exec -- ruby bgm.rb dubstep --shuffle
+```
+
 ## HOW IT WORKS
 
 bgm.rb uses [iTunes Store's Search API](https://www.apple.com/itunes/affiliates/resources/documentation/itunes-store-web-service-search-api.html).

--- a/bgm.rb
+++ b/bgm.rb
@@ -5,6 +5,7 @@ require "open-uri"
 class BGM
   def each(term)
     tracks = ITunesSearchAPI.search(term: term, country: "JP", media: "music", limit: async? ? 10 : 200)
+    tracks.shuffle! if @shuffle
     tracks.each{|track|
       yield lookup track
     }
@@ -38,6 +39,10 @@ class BGM
 
   def async!
     @async = true
+  end
+
+  def shuffle!
+    @shuffle = true
   end
 
   def rate(value)
@@ -79,6 +84,9 @@ while ARGV.length > 0
   v = ARGV.shift
   if v ==  '--async'
     bgm.async!
+  end
+  if v ==  '--shuffle'
+    bgm.shuffle!
   end
   if v ==  '--rate'
     bgm.rate(ARGV.shift)


### PR DESCRIPTION
bgm.rb always plays tracks in same order. We got bored :dancers:

I propose a `--shuffle` option to shuffle tracks.
Now, we can get a nice music in random order.

```
$ bundle exec -- ruby bgm.rb "Crystal Castel" --shuffle
```
